### PR TITLE
Support new libdweb UDPSocket API

### DIFF
--- a/test/manifest.json
+++ b/test/manifest.json
@@ -7,11 +7,11 @@
 
   "experiment_apis": {
     "UDPSocket": {
-      "schema": "../node_modules/libdweb/src/UDPSocket/UDPSocket.json",
+      "schema": "../node_modules/libdweb/src/toolkit/components/extensions/schemas/udp.json",
       "child": {
         "scopes": ["addon_child"],
         "paths": [["UDPSocket"]],
-        "script": "../node_modules/libdweb/src/UDPSocket/Socket.js"
+        "script": "../node_modules/libdweb/src/toolkit/components/extensions/child/ext-udp.js"
       }
     }
   },


### PR DESCRIPTION
The `UDPSocket` API was changed in https://github.com/mozilla/libdweb/commit/4d6cdee2ac43dfafffa234fcfc9a3e1cc4873e7e . This PR updates this library use the new API.

The flow tests are passing for me locally, but I'm not sure how the tape tests are meant to run on this repo, or if they were running before. Please let me know if there is something I can do to get them running @Gozala 